### PR TITLE
fix: data getting fetched twice, when using filters

### DIFF
--- a/src/frontend/vue/src/components/DataTablePage.vue
+++ b/src/frontend/vue/src/components/DataTablePage.vue
@@ -130,9 +130,10 @@
     await loadDataAndHandleMessage();
   });
 
-  watch(() => props.options.dataStore.pagination.totalEntries, async (newValue, oldValue) => {
-    if (oldValue !== undefined) {
+  watch(() => props.options.dataStore.reloadData, async (newValue, oldValue) => {
+    if (newValue === true) {
       await loadDataAndHandleMessage();
+      props.options.dataStore.reloadData = false;
     }
   });
 

--- a/src/frontend/vue/src/stores/DataListStore.js
+++ b/src/frontend/vue/src/stores/DataListStore.js
@@ -14,7 +14,8 @@ export const useDataListStore = defineStore("DataList", {
       item: "",
       items: ""
     },
-    isLoading: false
+    isLoading: false,
+    reloadData: false
   }),
 
   actions: {
@@ -58,7 +59,7 @@ export const useDataListStore = defineStore("DataList", {
           if (deleteStatus.includes(true)) {
             console.log("deleting success", deleteStatus.length);
             // trigger the watcher to reload the page
-            this.pagination.totalEntries -= deleteStatus.length;
+            this.reloadData = true;
            // return [true, undefined];
           }
         }


### PR DESCRIPTION
fix for #64 

instead of watching the totalEntries property, watch a dedicated "reloadData" property, that we trigger to reload the page